### PR TITLE
Use HTTPS links instead of HTTP

### DIFF
--- a/blaze-builder.nix
+++ b/blaze-builder.nix
@@ -11,7 +11,7 @@ mkDerivation {
     base bytestring HUnit QuickCheck test-framework
     test-framework-hunit test-framework-quickcheck2 text utf8-string
   ];
-  homepage = "http://github.com/lpsmith/blaze-builder";
+  homepage = "https://github.com/lpsmith/blaze-builder";
   description = "Efficient buffered output";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/elpa-packages.sh
+++ b/elpa-packages.sh
@@ -3,4 +3,4 @@
 
 # usage: ./elpa-packages.sh -o PATH
 
-cabal run elpa2nix -- http://elpa.gnu.org/packages/ "$@"
+cabal run elpa2nix -- https://elpa.gnu.org/packages/ "$@"

--- a/kan-extensions.nix
+++ b/kan-extensions.nix
@@ -10,7 +10,7 @@ mkDerivation {
     adjunctions array base comonad containers contravariant
     distributive free mtl semigroupoids tagged transformers
   ];
-  homepage = "http://github.com/ekmett/kan-extensions/";
+  homepage = "https://github.com/ekmett/kan-extensions/";
   description = "Kan extensions, Kan lifts, various forms of the Yoneda lemma, and (co)density (co)monads";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/lens.nix
+++ b/lens.nix
@@ -26,7 +26,7 @@ mkDerivation {
     test-framework-quickcheck2 test-framework-th text transformers
     unordered-containers vector
   ];
-  homepage = "http://github.com/ekmett/lens/";
+  homepage = "https://github.com/ekmett/lens/";
   description = "Lenses, Folds and Traversals";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/src/Distribution/Melpa.hs
+++ b/src/Distribution/Melpa.hs
@@ -217,7 +217,7 @@ getFetcher _ sourceDir SVN {..} = do
 getFetcher name _ Wiki {..} = do
   let
     url = fromMaybe defaultUrl wikiUrl
-    defaultUrl = "http://www.emacswiki.org/emacs/download/" <> name <> ".el"
+    defaultUrl = "https://www.emacswiki.org/emacs/download/" <> name <> ".el"
   pure Nix.URL { Nix.url = url
                , Nix.sha256 = Nothing
                }

--- a/src/Distribution/Nix/Package/Elpa.hs
+++ b/src/Distribution/Nix/Package/Elpa.hs
@@ -62,7 +62,7 @@ expression (Package {..}) = (mkSym "callPackage") `mkApp` drv `mkApp` emptySet w
              ]
         where
           homepage = T.concat
-                     [ "http://elpa.gnu.org/packages/"
+                     [ "https://elpa.gnu.org/packages/"
                      , ename
                      , ".html"
                      ]

--- a/src/Distribution/Nix/Package/Melpa.hs
+++ b/src/Distribution/Nix/Package/Melpa.hs
@@ -68,7 +68,7 @@ expression (Package {..}) = (mkSym "callPackage") `mkApp` drv `mkApp` emptySet w
              , "license" `bindTo` license
              ]
         where
-          homepage = T.append "http://melpa.org/#/" (ename recipe)
+          homepage = T.append "https://melpa.org/#/" (ename recipe)
           license = Fix (NSelect (mkSym "lib") [StaticKey "licenses", StaticKey "free"] Nothing)
       fetchRecipe = (mkApp (mkSym "fetchurl") . mkNonRecSet)
                     [ "url" `bindTo` mkStr DoubleQuoted


### PR DESCRIPTION
Unfortunately, orgmode.org doesn't support it,
but all other URLs have been changed.

refs https://github.com/NixOS/nixpkgs/issues/13809
