### PR TITLE
Fix various downloading options; error messages

### DIFF
--- a/melpa-packages.sh
+++ b/melpa-packages.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -A env
+#!nix-shell -i bash -A env
 
 # usage: ./melpa-packages.sh --melpa PATH_TO_MELPA_CLONE
+
+## env var for curl
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 cabal run melpa2nix -- --work /tmp/melpa2nix "$@"

--- a/melpa-stable-packages.sh
+++ b/melpa-stable-packages.sh
@@ -3,4 +3,7 @@
 
 # usage: ./melpa-packages.sh --melpa PATH_TO_MELPA_CLONE
 
+## env var for curl
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
 cabal run melpa2nix -- --stable --work /tmp/melpa2nix "$@"

--- a/shell.nix
+++ b/shell.nix
@@ -11,8 +11,6 @@ let
         enableLibraryProfiling = profiling;
       });
 
-      aeson = self.aeson_0_11_1_4;
-      bifunctors = lib.dontHaddock self.bifunctors_5_2_1;
       comonad = lib.doJailbreak (lib.dontCheck super.comonad);
       distributive = lib.dontCheck super.distributive;
       fail = lib.dontHaddock super.fail;
@@ -22,7 +20,6 @@ let
       parsers = lib.doJailbreak super.parsers;
       reducers = lib.doJailbreak super.reducers;
       semigroupoids = lib.dontCheck super.semigroupoids;
-      transformers-compat = self.transformers-compat_0_5_1_4;
       trifecta = lib.doJailbreak (lib.dontCheck super.trifecta);
       unordered-containers = lib.doJailbreak super.unordered-containers;
     };

--- a/src/Distribution/Nix/Fetch.hs
+++ b/src/Distribution/Nix/Fetch.hs
@@ -113,12 +113,12 @@ prefetchHelper :: String -> [String]
 prefetchHelper fetcher args go = mapException FetchError helper
   where
     helper = do
-      env <- (   addToEnv "PRINT_PATH" "1"
-              >> addToEnv "SSL_CERT_FILE" "/etc/ssl/certs/ca-certificates.crt")
+      env <- addToEnv [("PRINT_PATH",    "1"),
+                       ("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt")]
       runInteractiveProcess fetcher args Nothing (Just env) go
 
-addToEnv :: MonadIO m => String -> String -> m [(String, String)]
-addToEnv var val = liftIO $ M.toList . M.insert var val . M.fromList <$> getEnvironment
+addToEnv :: [(String, String)] -> IO [(String, String)]
+addToEnv env = (++ env) <$> getEnvironment
 
 data BadPrefetchOutput = BadPrefetchOutput
   deriving (Show, Typeable)

--- a/src/Distribution/Nix/Fetch.hs
+++ b/src/Distribution/Nix/Fetch.hs
@@ -113,7 +113,8 @@ prefetchHelper :: String -> [String]
 prefetchHelper fetcher args go = mapException FetchError helper
   where
     helper = do
-      env <- addToEnv "PRINT_PATH" "1"
+      env <- (   addToEnv "PRINT_PATH" "1"
+              >> addToEnv "SSL_CERT_FILE" "/etc/ssl/certs/ca-certificates.crt")
       runInteractiveProcess fetcher args Nothing (Just env) go
 
 addToEnv :: MonadIO m => String -> String -> m [(String, String)]

--- a/src/Distribution/Nix/Fetch.hs
+++ b/src/Distribution/Nix/Fetch.hs
@@ -162,7 +162,7 @@ prefetch _ fetch@(Hg {..}) = do
   prefetchHelper "nix-prefetch-hg" args $ \out -> do
     hashes <- liftIO (S.lines out >>= S.decodeUtf8 >>= S.toList)
     case hashes of
-      (_:hash:path:_) -> pure (T.unpack path, fetch { sha256 = Just hash })
+      (hash:path:_) -> pure (T.unpack path, fetch { sha256 = Just hash })
       _ -> throwIO BadPrefetchOutput
 
 prefetch name fetch@(CVS {..}) = do

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -55,10 +55,9 @@ runInteractiveProcess cmd args cwd env withOutput
       getOutput = Concurrently (withOutput out)
       getErrors = Concurrently (S.fold (<>) T.empty =<< S.decodeUtf8 err)
       wait = Concurrently (S.waitForProcess pid)
-    (result, errorMessage, exit) <- runConcurrently
-                                    ((,,) <$> getOutput <*> getErrors <*> wait)
+    (errorMessage, exit) <- runConcurrently ((,) <$> getErrors <*> wait)
     case exit of
-      ExitSuccess -> pure result
+      ExitSuccess -> runConcurrently getOutput
       ExitFailure code -> throwIO (Died code errorMessage)
 
 showExceptions :: IO b -> IO (Maybe b)

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -33,6 +33,7 @@ import Data.Typeable (Typeable)
 import System.Exit (ExitCode(..))
 import System.IO.Streams (InputStream)
 import qualified System.IO.Streams as S
+import Debug.Trace
 
 data Died = Died Int Text
   deriving (Show, Typeable)
@@ -44,6 +45,14 @@ data ProcessFailed = ProcessFailed String [String] SomeException
 
 instance Exception ProcessFailed
 
+data ProcessingFailed = ProcessingFailed Text Text SomeException
+  deriving (Show, Typeable)
+
+instance Exception ProcessingFailed
+
+slurp :: InputStream ByteString -> IO Text
+slurp stream = S.fold (<>) T.empty =<< S.decodeUtf8 stream
+
 runInteractiveProcess
   :: String -> [String] -> Maybe FilePath -> Maybe [(String, String)]
   -> (InputStream ByteString -> IO a)
@@ -52,13 +61,25 @@ runInteractiveProcess cmd args cwd env withOutput
   = mapExceptionIO (ProcessFailed cmd args) $ do
     (_, out, err, pid) <- S.runInteractiveProcess cmd args cwd env
     let
-      getOutput = Concurrently (withOutput out)
-      getErrors = Concurrently (S.fold (<>) T.empty =<< S.decodeUtf8 err)
+      getOutput =
+        Concurrently
+         (catch
+          (fmap Right $ withOutput out)
+          (\e -> (fmap (Left . ((,) e)) (slurp out))))
+          ---- Maybe catch exceptions that might occur by just slurping the input stream
+          ---- couldn't get this to type (Ambigous exception type)
+          -- (\e -> catch
+          --        (fmap (Left . ((,) e)) (slurp out))
+          --        -- (Left (e, slurp out))
+          --        (\ei -> pure $ Left (e, T.pack $ "INPUT ERROR " ++ show ei))))
+      getErrors = Concurrently $ slurp err
       wait = Concurrently (S.waitForProcess pid)
-    (errorMessage, exit) <- runConcurrently ((,) <$> getErrors <*> wait)
-    case exit of
-      ExitSuccess -> runConcurrently getOutput
-      ExitFailure code -> throwIO (Died code errorMessage)
+    (output, errorMessage, exit) <- runConcurrently ((,,) <$> getOutput <*> getErrors <*> wait)
+    case (exit, output) of
+      (ExitSuccess, Right v) -> pure v
+      (ExitSuccess, Left (ex, leftover)) -> throwIO $ ProcessingFailed leftover errorMessage ex
+      (ExitFailure code, Left info) -> throwIO $ trace (show info) $ Died code errorMessage
+      (ExitFailure code, Right v) -> throwIO $ Died code "WTF successful parse of error'd program"
 
 showExceptions :: IO b -> IO (Maybe b)
 showExceptions go = catch (Just <$> go) handler


### PR DESCRIPTION
`Util.runInteractiveProcess` doesn't show errors from subprocesses, because `getOutput` throws, when the subprocess fails.
This patch reorders `getOutput` into a match on `ExitSuccess` thus unmasking error messages.
