### PR TITLE
mappend is no longer pulled in as a side-effect

### DIFF
--- a/elpa2nix.hs
+++ b/elpa2nix.hs
@@ -35,6 +35,7 @@ import Data.ByteString ( ByteString )
 import Data.Map.Strict ( Map )
 import qualified Data.Map.Strict as M
 import Data.Maybe ( catMaybes )
+import Data.Monoid ((<>))
 import Data.Text ( Text )
 import qualified Data.Text as T
 import Data.Typeable ( Typeable )

--- a/melpa2nix.hs
+++ b/melpa2nix.hs
@@ -26,6 +26,7 @@ module Main where
 
 import Control.Concurrent ( getNumCapabilities, setNumCapabilities )
 import Control.Monad ( join )
+import Data.Monoid ((<>))
 import Data.Set ( Set )
 import qualified Data.Set as Set
 import Data.Text ( Text )


### PR DESCRIPTION
Looks like the move to stackage-8.0 brought in a version that no longer exported mappend by default.