### PR TITLE
Fixup get-deps.el

### DIFF
--- a/scripts/get-deps.el
+++ b/scripts/get-deps.el
@@ -30,7 +30,7 @@
                               (package-build--get-package-info pkg-source))))
               (deps (apply 'append
                            (mapcar (lambda (dep)
-                                     (list (package-build--sym-to-keyword (car dep))
+                                     (list (intern (format ":%s" (car dep)))
                                            (cadr dep)))
                                    (elt pkg-info 1)))))
          (if deps (princ (json-encode deps)) (princ "{}")))))))


### PR DESCRIPTION
https://github.com/melpa/package-build/commit/9b4b75c4ad3f0323d06132c5f6a3f646991e5c15
removed `package-build--sym-to-keyword`.  This just recapitulates the
change in our one use.