### PR TITLE
Fix invocation of package-build.el

### DIFF
--- a/src/Distribution/Melpa/Recipe.hs
+++ b/src/Distribution/Melpa/Recipe.hs
@@ -78,11 +78,13 @@ instance FromJSON Recipe where
 
 readRecipes :: FilePath -> IO (Map Text Recipe)
 readRecipes melpaDir = do
-  let packageBuildEl = melpaDir </> "package-build" </> "package-build.el"
+  let packageBuildDir = melpaDir </> "package-build"
+      packageBuildEl = "package-build.el"
       recipesDir = melpaDir </> "recipes"
   dumpRecipesEl <- getDataFileName "dump-recipes.el"
   let args = [ "-Q"
              , "--batch"
+             , "-L", packageBuildDir
              , "-l", packageBuildEl
              , "-l", dumpRecipesEl
              , "-f", "dump-recipes-json", recipesDir


### PR DESCRIPTION
It was split into multiple files, which means we need to get its
containing directory in the load-path, so the various parts can be
required.