### PR TITLE
Use HTTPS for Org ELPA to avoid a redirect

### DIFF
--- a/org-packages.sh
+++ b/org-packages.sh
@@ -3,4 +3,4 @@
 
 # usage: ./org-packages.sh -o PATH
 
-elpa2nix http://orgmode.org/elpa/ "$@"
+elpa2nix https://orgmode.org/elpa/ "$@"


### PR DESCRIPTION
Curl does not follow redirects by default (one can use the `-L` option for that), and http://orgmode.org/elpa/archive-contents returns a "301 Moved Permanently" status code. Should fix #49.