### PR TITLE
End generated Nix files with trailing newlines

### DIFF
--- a/src/Distribution/Nix/Index.hs
+++ b/src/Distribution/Nix/Index.hs
@@ -74,6 +74,7 @@ writeIndex output packages = do
     write index out = do
       let rendered = renderSmart 1.0 80 (prettyNix index)
       displayStream rendered =<< S.encodeUtf8 out
+      S.write (Just "\n") =<< S.encodeUtf8 out
 
 getFunctionBody :: NExpr -> Maybe NExpr
 getFunctionBody (Fix (NAbs _ body)) = Just body


### PR DESCRIPTION
Nixpkgs now has a CI action that enforces this, so without this
change, elpa2nix files can't be added without modification.