### PR TITLE
Use GitLab API path for archive downloads

### DIFF
--- a/emacs2nix.cabal
+++ b/emacs2nix.cabal
@@ -84,6 +84,7 @@ library
     , time >=1.5
     , transformers >=0.4
     , unordered-containers >=0.2
+    , uri-encode >= 1.5
   default-language: Haskell2010
 
 executable elpa2nix
@@ -118,6 +119,7 @@ executable elpa2nix
     , time >=1.5
     , transformers >=0.4
     , unordered-containers >=0.2
+    , uri-encode >= 1.5
   default-language: Haskell2010
 
 executable melpa2nix
@@ -152,4 +154,5 @@ executable melpa2nix
     , time >=1.5
     , transformers >=0.4
     , unordered-containers >=0.2
+    , uri-encode >= 1.5
   default-language: Haskell2010

--- a/package.nix
+++ b/package.nix
@@ -2,7 +2,7 @@
 , bytestring, containers, data-fix, directory, errors, exceptions
 , filepath, hashable, hnix, http-streams, io-streams
 , optparse-applicative, scientific, stdenv, taggy, template-haskell
-, temporary, text, time, transformers, unordered-containers
+, temporary, text, time, transformers, unordered-containers, uri-encode
 }:
 mkDerivation {
   pname = "emacs2nix";
@@ -15,14 +15,14 @@ mkDerivation {
     aeson ansi-wl-pprint async attoparsec base bytestring containers
     data-fix directory errors exceptions filepath hashable hnix
     http-streams io-streams scientific taggy template-haskell temporary
-    text time transformers unordered-containers
+    text time transformers unordered-containers uri-encode
   ];
   executableHaskellDepends = [
     aeson ansi-wl-pprint async attoparsec base bytestring containers
     data-fix directory errors exceptions filepath hashable hnix
     http-streams io-streams optparse-applicative scientific taggy
     template-haskell temporary text time transformers
-    unordered-containers
+    unordered-containers uri-encode
   ];
   homepage = "https://github.com/ttuegel/emacs2nix#readme";
   description = "Generate Nix expressions for Emacs packages";

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ dependencies:
   - time >= 1.5
   - transformers >= 0.4
   - unordered-containers >= 0.2
+  - uri-encode >= 1.5
 
 ghc-options: -Wall
 

--- a/src/Distribution/Nix/Fetch.hs
+++ b/src/Distribution/Nix/Fetch.hs
@@ -32,6 +32,7 @@ import Data.Monoid
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Typeable (Typeable)
+import Network.URI.Encode (encodeText)
 import Nix.Expr
 import System.Environment (getEnvironment)
 import qualified System.IO.Streams as S
@@ -225,8 +226,10 @@ prefetch _ fetch@(GitHub {..}) = do
 prefetch _ fetch@(GitLab {..}) = do
   let
     args = ["--name", T.unpack name, "--unpack", T.unpack url]
-    url = "https://gitlab.com/" <> owner <> "/" <> repo
-          <> "/repository/archive.tar.gz?ref=" <> rev
+    slug = encodeText $ owner <> "/" <> repo
+    escapedRev = encodeText rev
+    url = "https://gitlab.com/api/v4/projects/" <> slug
+      <> "/repository/archive.tar.gz?sha=" <> escapedRev
     name = repo <> "-" <> rev <> "-src"
   prefetchHelper "nix-prefetch-url" args $ \out -> do
     hashes <- liftIO (S.lines out >>= S.decodeUtf8 >>= S.toList)


### PR DESCRIPTION
Use similar archive fetch URL as [fetchgitlab][0] from [nixpkgs][1].
This archive scheme is documented in the [GitLab API docs][2].

[0]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgitlab/default.nix

[1]: https://github.com/NixOS/nixpkgs

[2]: https://docs.gitlab.com/ce/api/repositories.html#get-file-archive

This resolves ttuegel/emacs2nix#56 and nix-community/emacs-overlay#128.