### PR TITLE
Set up GitHub Actions for continous integration 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: build
+on: [push, pull_request]
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      with:
+        submodule: recursive
+    - uses: cachix/install-nix-action@v16
+      with:
+        nix_path: nixpkgs=channel:nixos-21.11
+    - run: nix-shell --command nix-build
+    # - run: nix flake check # maybe some day


### PR DESCRIPTION
Hello, 
i saw the issue and thought i could fix this. 

**This needs to be committed to the master branch. On other branches github will ignore the workflow.**

Features:
 - checkout git
 - nix action with cachix is used to set up nix
 - currently on nixos-21.11
 - command nix-shell --command nix-build

Entering the `nix-shell` fails caused by this error:
`error: 1 dependencies of derivation '/nix/store/nr0xdsp7p3nrwi5wbzrnhqc6yij5wknx-ghc-8.2.2-with-packages.drv' failed to build
Error: Process completed with exit code 1.`

I think this is not a error of the CI/CD. 

TODOs:

1. Is nixos-21.11 the version were you want to build this?
2. Maybe you know the exact command that should be run so pleas comment them here and i will add them. 
3. The nix-shell is taking some time to be created. Does the shell only contain the dependencies for the build? Maybe something can be removed to speed up the process. 