### PR TITLE
Add cl-print as a built-in package

### DIFF
--- a/src/Distribution/Nix/Builtin.hs
+++ b/src/Distribution/Nix/Builtin.hs
@@ -42,6 +42,7 @@ optionalBuiltins dep
               , "chart"
               , "checkdoc"
               , "cl-lib"
+              , "cl-print"
               , "cwarn"
               , "delim-col"
               , "dunnet"


### PR DESCRIPTION
The elpa builder, when using the nixos-22.11 or nixos-unstable branches of nixpkgs, is producing an elpa-generated.nix that fails due to packages requiring cl-print, but there being no cl-print package.

cl-print is not in the Elpa index (Though it is on its own page...). This could be a bug in Elpa.

However, cl-print is a built-in package, so should not need to be provided. This PR attempts to fix the issue by adding cl-print to the list of built-in packages.

I have not tested this change myself, though putting this PR up in case someone more familiar with this project can check.

For more context, see: https://github.com/nix-community/emacs-overlay/issues/266
