### PR TITLE
elpa2nix: filter out emacs from dependencies to reduce closure size

### DIFF
--- a/elpa2nix.hs
+++ b/elpa2nix.hs
@@ -207,7 +207,8 @@ hashPackage server namesMap (name, pkg) =
 
     nixName <- Nix.getName namesMap (Emacs.Name name)
     nixDeps <- mapM (Nix.getName namesMap . Emacs.Name)
-              (maybe [] M.keys (Elpa.deps pkg))
+              $ filter (\dep -> dep /= "emacs") -- filter dummy dep emacs to reduce closure size
+              $ (maybe [] M.keys (Elpa.deps pkg))
 
     pure Nix.Package
       { Nix.pname = nixName


### PR DESCRIPTION
emacs used as a dependency is only to indicate[1] the minimal support Emacs version.  Since the version info is dropped here, filtering out emacs has no cost but only benefit.

If `emacs` is in `packageRequires`, it will be added to `propagatedBuildInputs` and `propagatedUserEnvPkgs`, which pulls `emacs` into the closure of an Elisp package.

This change does break a user's config if he only explicitly installs Elisp packages without explicitly installing Emacs itself.  Presumably, no one uses this weird config.  I would say this change is safe.

[1]: info "(elisp) Library Headers"