### PR TITLE
elpa2nix: handle more versions with non-digit chars

### DIFF
--- a/elpa2nix.hs
+++ b/elpa2nix.hs
@@ -183,10 +183,14 @@ hashPackage :: String -> HashMap Emacs.Name Name -> (Text, Elpa)
 hashPackage server namesMap (name, pkg) =
   catchPretty $ do
     let
+      -- ver can not be completely correct but works well for now
+      -- see doc string of version-regexp-alist and version-to-list
       ver = (Elpa.ver pkg) &
         ((map (T.pack . show))
         >>> (T.intercalate ".")
         >>> (T.replace ".-4." "snapshot")
+        >>> (T.replace ".-3." "alpha")
+        >>> (T.replace ".-2." "beta")
         >>> (T.replace ".-1." "pre"))
       basename
         | null (Elpa.ver pkg) = T.unpack name


### PR DESCRIPTION
A follow-up of de8644f3ce188cf540bf83d673a2859d38568701.

Bug: https://github.com/NixOS/nixpkgs/issues/346034